### PR TITLE
bug fix for concatenate-across-lanes.sh. Also added check for existin…

### DIFF
--- a/scripts/concatenate-across-lanes.sh
+++ b/scripts/concatenate-across-lanes.sh
@@ -28,7 +28,14 @@ if [[ -z "${1}" ]]; then
   exit 1
 fi
 
-# optional second argument. if pass 'dry' as second argument, don't concatenate, just echo cat commands
+# check to see if merged reads already exist in TARGET dir, exit if yes
+if exists ${TARGET_DIR}/*merged*.fastq.gz ; then
+  echo "It appears that merged/concatenated reads already exist in ${TARGET_DIR}"
+  echo "Exiting."
+  exit 1
+fi
+
+# optional second argument. if pass 'dry' as second argument, don't concatenate, just echo the cat commands
 DRY_RUN=$2
 if [[ "${DRY_RUN}" == "dry" ]]; then
   echo "DRY RUN OPTION SPECIFIED, NOT ACTUALLY CONCATENATING HERE..."
@@ -36,11 +43,11 @@ if [[ "${DRY_RUN}" == "dry" ]]; then
   # STARTING FROM 22ND CHARACTER, PRINT TIL THE END. THIS IS THE VARIABLE F WHICH IS THE SAMPLE ID
   for i in $(find ${TARGET_DIR} -maxdepth 1 -type f -name "*.fastq.gz" | while read F; do basename $F | rev | cut -c 22- | rev; done | sort | uniq); do
       echo "Merging R1 for ${i}"
-      echo "cat "${i}"_L00*_R1_001.fastq.gz > "${i}"_merged_R1.fastq.gz"
+      echo "cat ${TARGET_DIR}/${i}_L00*_R1_001.fastq.gz > ${TARGET_DIR}/${i}_merged_R1.fastq.gz"
     # check to see if R2 exists before concatenating & making an empty file when there is no R2
     if exists ${TARGET_DIR}/${i}*R2*.fastq.gz ; then
       echo "Merging R2 for ${i}"
-      echo "cat "${i}"_L00*_R2_001.fastq.gz > "${i}"_merged_R2.fastq.gz"
+      echo "cat "${TARGET_DIR}/${i}"_L00*_R2_001.fastq.gz > "${TARGET_DIR}/${i}"_merged_R2.fastq.gz"
     else
        echo "R2 file for ${i} was not found. Skipping R2 concatenation..."
     fi
@@ -53,11 +60,11 @@ fi
 # maxdepth 1 so it only looks for fastq.gz's in the supplied path
 for i in $(find ${TARGET_DIR} -maxdepth 1 -type f -name "*.fastq.gz" | while read F; do basename $F | rev | cut -c 22- | rev; done | sort | uniq); do
   echo "Merging R1 for ${i}"
-  cat "${i}"_L00*_R1_001.fastq.gz > "${i}"_merged_R1.fastq.gz
+  cat ${TARGET_DIR}/${i}_L00*_R1_001.fastq.gz > ${TARGET_DIR}/${i}_merged_R1.fastq.gz
   # check to see if R2 exists before concatenating & making an empty file when there is no R2
   if exists ${TARGET_DIR}/${i}*R2*.fastq.gz ; then
     echo "Merging R2 for ${i}"
-    cat "${i}"_L00*_R2_001.fastq.gz > "${i}"_merged_R2.fastq.gz
+    cat ${TARGET_DIR}/${i}_L00*_R2_001.fastq.gz > ${TARGET_DIR}/${i}_merged_R2.fastq.gz
   else
     echo "R2 file for ${i} was not found. Skipping R2 concatenation..."
   fi


### PR DESCRIPTION
…g merged/concatenated fastqs prior to concatenation

Quick bug fix to address #1 

You can now concatenate-across-lanes from any directory:
```
$ concatenate-across-lanes.sh tests-galore/outputs/2022-02-08-concatenate-across-lanes-bugfix/
TARGET_DIR is set to tests-galore/outputs/2022-02-08-concatenate-across-lanes-bugfix/
Merging R1 for 3000301880_S251
Merging R2 for 3000301880_S251
Merging R1 for 3000301881_S258
Merging R2 for 3000301881_S258
Merging R1 for 3000301882_S266
Merging R2 for 3000301882_S266
Tue Feb  8 21:01:58 UTC 2022
DONE 

$ ll -h tests-galore/outputs/2022-02-08-concatenate-across-lanes-bugfix/
total 790M
drwxrwxr-x 2 curtis_kapsak curtis_kapsak 4.0K Feb  8 21:01 ./
drwxrwxr-x 3 curtis_kapsak curtis_kapsak 4.0K Feb  8 20:32 ../
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  34M Feb  8 20:34 3000301880_S251_L001_R1_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  36M Feb  8 20:34 3000301880_S251_L001_R2_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  34M Feb  8 20:34 3000301880_S251_L002_R1_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  36M Feb  8 20:34 3000301880_S251_L002_R2_001.fastq.gz*
-rw-rw-r-- 1 curtis_kapsak curtis_kapsak  68M Feb  8 21:01 3000301880_S251_merged_R1.fastq.gz
-rw-rw-r-- 1 curtis_kapsak curtis_kapsak  71M Feb  8 21:01 3000301880_S251_merged_R2.fastq.gz
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  39M Feb  8 20:34 3000301881_S258_L001_R1_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  40M Feb  8 20:34 3000301881_S258_L001_R2_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  39M Feb  8 20:34 3000301881_S258_L002_R1_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  40M Feb  8 20:34 3000301881_S258_L002_R2_001.fastq.gz*
-rw-rw-r-- 1 curtis_kapsak curtis_kapsak  77M Feb  8 21:01 3000301881_S258_merged_R1.fastq.gz
-rw-rw-r-- 1 curtis_kapsak curtis_kapsak  80M Feb  8 21:01 3000301881_S258_merged_R2.fastq.gz
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  25M Feb  8 20:34 3000301882_S266_L001_R1_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  26M Feb  8 20:35 3000301882_S266_L001_R2_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  25M Feb  8 20:35 3000301882_S266_L002_R1_001.fastq.gz*
-rwxrwxr-- 1 curtis_kapsak curtis_kapsak  26M Feb  8 20:35 3000301882_S266_L002_R2_001.fastq.gz*
-rw-rw-r-- 1 curtis_kapsak curtis_kapsak  50M Feb  8 21:01 3000301882_S266_merged_R1.fastq.gz
-rw-rw-r-- 1 curtis_kapsak curtis_kapsak  52M Feb  8 21:01 3000301882_S266_merged_R2.fastq.gz

$ concatenate-across-lanes.sh tests-galore/outputs/2022-02-08-concatenate-across-lanes-bugfix/
TARGET_DIR is set to tests-galore/outputs/2022-02-08-concatenate-across-lanes-bugfix/
It appears that merged/concatenated reads already exist in tests-galore/outputs/2022-02-08-concatenate-across-lanes-bugfix/
Exiting.
```