### PR TITLE
[Taxon_Tables] Create a utility to update task_broad_terra_tables.wdl in PHB

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,7 +133,7 @@ Now check the nextclade_versions.csv to see what nextclade tags need to be udpat
 
 ### update_taxon_tables_io.py
 
-This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report which additions and removals need to be made to the task and downstream workflow dependencies. It currently operates locally, though is staged for remote operation following minor changes.
+This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report which additions and removals need to be made to the task and downstream workflow dependencies. It currently operates locally, identifying downstream dependencies dynamically, though this script is staged for remote operation using hard-coded dependency links following minor changes. This script is also staged to update these files in place.
 
 #### requirements
 Two inputs required:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -135,6 +135,8 @@ Now check the nextclade_versions.csv to see what nextclade tags need to be udpat
 
 This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report which additions and removals need to be made to the task and downstream workflow dependencies. It currently operates locally, identifying downstream dependencies dynamically, though this script is staged for remote operation using hard-coded dependency links following minor changes. This script is also staged to update these files in place.
 
+NOTE: The WDL library will fail to parse dependencies if it cannot link I/O between workflows and task. If no updates are necessary then nothing will be printed for the dependency files.
+
 #### requirements
 Two inputs required:
  - Local Git repo (PHB) directory

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,5 +143,5 @@ MiniWDL is a required package
 
 #### usage
 ```bash
-$ python update_taxon_tables.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl> 
+$ python update_taxon_tables_io.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl> 
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,14 +133,14 @@ Now check the nextclade_versions.csv to see what nextclade tags need to be udpat
 
 ### update_taxon_tables_io.py
 
-This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report in `$PWD/update_taxon_tables_io.out` which additions and removals need to be made to the task, downstream workflow dependencies, and documentation. It currently operates locally, identifying downstream dependencies dynamically, though this script is staged for remote operation using hard-coded dependency links following minor changes. This script is also staged to update these files in place.
+This python script synchronizes `task_export_taxon_table.wdl` I/O and its downstream dependencies' I/O. It will then report in `$PWD/update_taxon_tables_io.out` which additions and removals need to be made to task calls in downstream workflow dependencies. It currently operates locally, identifying downstream dependencies dynamically, though the scaffold is designed for remote operation and updating files in place using hard-coded dependency links following minor changes.
 
 NOTE: The WDL library will fail to parse dependencies if it cannot link I/O between workflows and task. If no updates are necessary then nothing will be printed for the dependency files.
 
 #### requirements
 Two inputs required:
  - Local Git repo (PHB) directory
- - `task_broad_terra_tools.wdl` within the repo
+ - `task_export_taxon_table.wdl` within the repo
 MiniWDL is a required package
 
 #### usage

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -133,7 +133,7 @@ Now check the nextclade_versions.csv to see what nextclade tags need to be udpat
 
 ### update_taxon_tables_io.py
 
-This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report which additions and removals need to be made to the task and downstream workflow dependencies. It currently operates locally, identifying downstream dependencies dynamically, though this script is staged for remote operation using hard-coded dependency links following minor changes. This script is also staged to update these files in place.
+This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report in `$PWD/update_taxon_tables_io.out` which additions and removals need to be made to the task, downstream workflow dependencies, and documentation. It currently operates locally, identifying downstream dependencies dynamically, though this script is staged for remote operation using hard-coded dependency links following minor changes. This script is also staged to update these files in place.
 
 NOTE: The WDL library will fail to parse dependencies if it cannot link I/O between workflows and task. If no updates are necessary then nothing will be printed for the dependency files.
 
@@ -145,5 +145,5 @@ MiniWDL is a required package
 
 #### usage
 ```bash
-$ python update_taxon_tables_io.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl> > suggested_updates.txt 
+$ python update_taxon_tables_io.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl>
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,5 +143,5 @@ MiniWDL is a required package
 
 #### usage
 ```bash
-$ python update_taxon_tables_io.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl> 
+$ python update_taxon_tables_io.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl> > suggested_updates.txt 
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -129,3 +129,19 @@ A shell script that checks nextclade dataset versions in the `wf_organism_parame
 ```
 
 Now check the nextclade_versions.csv to see what nextclade tags need to be udpated. 
+
+
+### update_taxon_tables_io.py
+
+This python script facilitates synchronization between `task_broad_terra_tools.wdl` I/O and its downstream dependencies' I/O. It will then report which additions and removals need to be made to the task and downstream workflow dependencies. It currently operates locally, though is staged for remote operation following minor changes.
+
+#### requirements
+Two inputs required:
+ - Local Git repo (PHB) directory
+ - `task_broad_terra_tools.wdl` within the repo
+MiniWDL is a required package
+
+#### usage
+```bash
+$ python update_taxon_tables.py -r <local_PHB_repo> -i <task_broad_terra_tools.wdl> 
+```

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -419,7 +419,7 @@ def main(input_file, downstream_wdls, repo_dir, out_file,
                       mapping_name, file_obj = out_obj)
     
 def cli():
-    base_repo_url = f'https://raw.githubusercontent.com/theiagen/public_health_bioinformatics/'
+  #  base_repo_url = f'https://raw.githubusercontent.com/theiagen/public_health_bioinformatics/'
     parser = argparse.ArgumentParser(description = "Sync task_export_taxon_table.wdl inputs/outputs " \
                                      + "with downstream dependencies.")
 #    parser.add_argument("-b", "--branch", default = 'main', 

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -332,6 +332,14 @@ def print_changes(input_file, input_inputs, wdl2out_hash,
     for inp in sorted(extra_inputs):
         print(f'{inp}')
 
+    print('\tReplace "new_table" with this:')
+    print('    new_table = {')
+    print('      "entity:${sample_table}_id": "~{samplename}"', end = '')
+    for in_var in sorted(task_in2type.keys()):
+        print(f',\n      "{in_var}": ' + '"~{' + f'{in_var}' + '}"', 
+              end = '')
+    print('\n    }')
+
             
 def main(input_file, dependencies, repo_dir, task_name = 'export_taxon_tables',
          ignored_inputs = {'cpu', 'memory', 'disk_size', 'docker'}):

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -283,7 +283,9 @@ def print_changes(input_file, input_inputs, wdl2out_hash,
                 inputs2expr[in_name] = in_var
 
         # The workflow's inputs and outputs are the only acceptable inputs to the task
-        acceptable_inputs = set(inputs2expr.keys()).union(set(outputs2expr.keys()))
+        acceptable_inputs_prep = set(inputs2expr.keys()).union(set(outputs2expr.keys()))
+        # Add special exceptions
+        acceptable_inputs = acceptable_inputs_prep.union(ignored_inputs)
         # Extraneous task inputs are preexisting inputs that aren't acceptable
         extra_inputs = set(preexisting[wdl_file]).difference(acceptable_inputs)
         # Only unexposed outputs are flagged for adding

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -293,7 +293,7 @@ def print_changes(input_file, input_inputs, wdl2out_hash,
 
         for missing_var in sorted(missing_inputs):
             missing_expr = outputs2expr[missing_var]
-            print(f'{missing_var} = {missing_expr}')
+            print(f'{missing_var} = {missing_expr},')
         print(f'\tRemove from {namespace}.{task_name} call:')
         for extra_var in sorted(extra_inputs):
             extra_expr = preexisting[wdl_file][extra_var]
@@ -323,7 +323,7 @@ def print_changes(input_file, input_inputs, wdl2out_hash,
     print('\tAdd to inputs:')
     for in_var in sorted(needed_inputs):
         # all types are assumed to be optional
-        print(f'{task_in2type[in_var]}? {in_var}')
+        print(f'{task_in2type[in_var]}? {in_var},')
 
     # Report the extraneous inputs for the input task
     extra_inputs_prep = set(input_inputs.keys()).difference(set(task_in2type.keys()))

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -26,7 +26,7 @@ from io import StringIO
 from collections import defaultdict
 
 logging.basicConfig(level = logging.DEBUG,
-                    format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                    format = '%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 def set_wdl_paths():
@@ -519,7 +519,7 @@ def cli():
             raise FileNotFoundError("ERROR: Repo directory is not a git repository")
         dependencies = []
 
-    out_file = format_path(os.getcwd() + '/update_taxon_tables_io.out')
+    out_file = format_path(os.getcwd() + '/update_taxon_tables_io.txt')
     main(source_task, dependencies, repo_uri, out_file, remote = remote)
 
 if __name__ == '__main__':

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -1,0 +1,356 @@
+#! /usr/bin/env python3
+
+"""
+Input task_broad_terra_tables.wdl (task) and PHB repo and identify task I/O that is
+discrepant with downstream workflows
+
+- Currently prints recommended changes, but staged for automated updating in place
+- Does not account for variables that have the same name, but different type declarations
+- Does not accomodate multiple calls to task in same workflow
+"""
+
+import os
+import re
+import sys
+import glob
+try:
+    import WDL 
+except ImportError:
+    sys.stderr.write("ERROR: WDL Python package not found\nInstall MiniWDL\n")
+    sys.exit(3)
+import argparse
+from collections import defaultdict
+
+
+def collect_files(directory = './', filetype = '*', recursive = False):
+    '''
+    Inputs: directory path, file extension (no "."), recursivity bool
+    Outputs: list of files with `filetype`
+    If the filetype is a list, split it, else make a list of the one entry.
+    Parse the environment variable if applicable. Then, obtain a clean, full 
+    version of the input directory. Glob to obtain the filelist for each 
+    filetype based on whether or not it is recursive.
+    '''
+
+    if type(filetype) == list:
+        filetypes = filetype.split()
+    else:
+        filetypes = [filetype]
+
+    directory = format_path(directory)
+    filelist = []
+    for filetype in filetypes:
+        if recursive:
+            filelist.extend( 
+                glob.glob(directory + "/**/*." + filetype, recursive = recursive)
+            )
+        else:
+            filelist.extend(
+                glob.glob(directory + "/*." + filetype, recursive = recursive) 
+            )
+
+    return filelist
+
+def eprint(*args, **kwargs):
+    """Print to stderr"""
+    print(*args, file=sys.stderr, **kwargs)
+
+def expand_env_var(path):
+    '''Expands environment variables by regex substitution'''
+
+    envs = re.findall(r'\$[^/]+', path)
+    for env in envs:
+        path = path.replace(env, os.environ[env.replace('$','')])
+
+    return path.replace('//','/')
+
+def format_path(path, force_dir = False):
+    '''Goal is to convert all path types to absolute path with explicit dirs'''
+
+    if path:
+        path = os.path.expanduser(path)
+        path = expand_env_var(path)
+    
+        if force_dir:
+            if not path.endswith('/'):
+                path += '/'
+        else:
+            if path.endswith('/'):
+                if not os.path.isdir(path):
+                    path = path[:-1]
+            else:
+                if os.path.isdir(path):
+                    path += '/'
+            if not path.startswith('/'):
+                path = os.getcwd() + '/' + path
+
+        path = path.replace('/./', '/')
+        while '/../' in path:
+            path = re.sub(r'[^/]+/\.\./(.*)', r'\1', path)
+    
+    return path
+
+def check_repo_head(repo_dir):
+    """Check if repo directory is a git repo"""
+    if os.path.isdir(f'{repo_dir}/.git'):
+        return True
+    else:
+        return False
+
+def get_io(wdl_file):
+    """Get imports from WDL file"""
+    wf = WDL.load(wdl_file)
+    task2inputs = {}
+    task2outputs = {}
+    wf2inputs = {}
+    wf2outputs = {}
+    # This may need to be updated to accomodate other instances
+    if wf.tasks:
+        for task in wf.tasks:
+            task2inputs[task.name] = task.inputs
+            task2outputs[task.name] = task.outputs
+    if wf.workflow:
+        wf2inputs[wf.workflow.name] = wf.workflow.inputs
+        wf2outputs[wf.workflow.name] = wf.workflow.outputs
+
+    #x_info = {'inputs': {'<task/wf_name>': [<input1>, <input2>, ...], ...},
+    task_info, wf_info = {}, {}
+    if task2inputs or task2outputs:
+        task_info = {'inputs': task2inputs, 'outputs': task2outputs}
+    if wf2inputs or wf2outputs:
+        wf_info = {'inputs': wf2inputs, 'outputs': wf2outputs}
+
+    return task_info, wf_info
+
+def obtain_namespace_inputs(wdl_file, namespace, task):
+    """Obtain the inputs of a task in a WDL file using REGEX"""
+    with open(wdl_file, 'r') as raw:
+        wdl_data = raw.read()
+    # prepare a compiled regex to find the task and its inputs
+    re_comp = re.compile(r'call\W+' + f'{namespace}\.{task}' + r'\W+{' \
+                       + r'\s+input:\s+([^}]+)', re.DOTALL)
+    matches = re_comp.findall(wdl_data)
+    if len(list(matches)) > 1:
+        eprint(f'ERROR: Multiple instances of {namespace}.{task} found in {wdl_file}' \
+                + ' - this script is not equipped to handle this')
+        sys.exit(4)
+    elif '{' in matches[0]:
+        eprint('ERROR: REGEX not equipped to handle nested "{" ' \
+             + f'in {namespace}.{task} in {wdl_file}')
+        sys.exit(5)
+    namespace_inputs = {}
+    input_list = matches[0].split('\n')
+    for input in input_list:
+        inp_data = input.strip().split('=')
+        if len(inp_data) == 2:
+            inp_name = inp_data[0].strip()
+            inp_expr = inp_data[1].strip().replace(',', '')
+            namespace_inputs[inp_name] = inp_expr
+
+    return namespace_inputs
+
+def get_downstream(foc_file, foc_info, wdl_files, 
+                   repo_dir, task = 'export_taxon_tables'):
+    """Get downstream dependencies of a WDL file"""
+    preexisting = {}
+    downstream = {}
+    for wdl_file in wdl_files:
+        wdl = WDL.load(wdl_file)
+        wdl_dir = os.path.dirname(wdl_file)
+        for wdl_import in wdl.imports:
+            uri = wdl_import.uri
+            uri_path = format_path(os.path.join(wdl_dir, uri))
+            if uri_path == foc_file:
+                eprint(f'\t{wdl_file}')
+                task_io, wf_io = get_io(wdl_file)
+                namespace = wdl_import.namespace
+                downstream[wdl_file] = {'namespace': namespace,
+                                        'outputs': wf_io['outputs'],
+                                        'inputs': wf_io['inputs']}
+                preexisting[wdl_file] = obtain_namespace_inputs(wdl_file, namespace, task)
+
+    return downstream, preexisting
+
+def get_upstream(foc_file, repo_dir):
+    """Get upstream dependencies of a WDL file"""
+    upstream = {}
+    wdl = WDL.load(foc_file)
+    wdl_dir = os.path.dirname(foc_file)
+    for wdl_import in wdl.imports:
+        uri = wdl_import.uri
+        uri_path = format_path(os.path.join(wdl_dir, uri))
+        upstream[uri_path] = wdl_import.namespace
+        eprint(uri_path, wdl_import.namespace)
+
+    return upstream
+
+def compile_outputs(io_dict):
+    """Identify the outputs to eventually 
+    populate the input script's inputs"""
+        # have to convert the WDL type objects to a proper string for hashing
+#   input_data = {(inp.name, str(inp.type),) for inp in inputs}
+    wdl2in2type = defaultdict(dict)
+    wdl2out2type = defaultdict(dict)
+    wdl2out_hash, wdl2in_hash = {}, {}
+    wdl2namespace = {}
+    for wdl_file, wdl_info in io_dict.items():
+        # namespace = wdl_info['namespace']
+        wdl2out_hash[wdl_file] = {}
+        wdl2in_hash[wdl_file] = {}
+        wdl2namespace[wdl_file] = wdl_info['namespace']
+        for task1, outputs in wdl_info['outputs'].items():
+            wdl2out_hash[wdl_file][task1] = []
+            # have to convert the WDL type objects to a proper string for hashing
+            for out in outputs:
+                wdl2out_hash[wdl_file][task1].append((out.name, out.expr,))
+                wdl2out2type[wdl_file][out.name] = str(out.type).replace('?', '')
+            wdl2out_hash[wdl_file][task1] = sorted(wdl2out_hash[wdl_file][task1])
+        for task1, inputs in wdl_info['inputs'].items():
+            wdl2in_hash[wdl_file][task1] = []
+            # have to convert the WDL type objects to a proper string for hashing
+            for in_ in inputs:
+                wdl2in2type[wdl_file][in_.name] = str(in_.type).replace('?', '')
+                wdl2in_hash[wdl_file][task1].append((in_.name, in_.expr,))
+            wdl2in_hash[wdl_file][task1] = sorted(wdl2in_hash[wdl_file][task1])
+
+    return wdl2out_hash, wdl2namespace, wdl2in_hash, wdl2in2type, wdl2out2type
+
+def print_changes(input_file, input_inputs, wdl2out_hash, 
+                  wdl2namespace, task_name, preexisting, task,
+                  ignored_inputs, wdl2in_hash, wdl2in2type, wdl2out2type):
+    """Print the input script's new inputs"""
+
+    # Identify and print inputs from the workflow that do not correspond
+    print()
+    task_in2type = defaultdict(set)
+    for wdl_file, task_dict in wdl2out_hash.items():
+        namespace = wdl2namespace[wdl_file]
+        print(f'{wdl_file}')
+        print(f'\tAdd to {namespace}.{task_name} call:')
+        outputs2expr, inputs2expr = {}, {}
+        for task0, outputs in task_dict.items():
+            for out_name, out_var in outputs:
+                outputs2expr[out_name] = out_var
+        for task0, inputs in wdl2in_hash[wdl_file].items():
+            for in_name, in_var in inputs:
+                inputs2expr[in_name] = in_var
+
+        # The workflow's inputs and outputs are the only acceptable inputs to the task
+        acceptable_inputs = set(inputs2expr.keys()).union(set(outputs2expr.keys()))
+        # Extraneous task inputs are preexisting inputs that aren't acceptable
+        extra_inputs = set(preexisting[wdl_file]).difference(acceptable_inputs)
+        # Only unexposed outputs are flagged for adding
+        missing_inputs = set(outputs2expr.keys()).difference(set(preexisting[wdl_file]))
+        # Identify the total inputs for populating the task file itself later
+        actual_inputs = set(preexisting[wdl_file]).intersection(acceptable_inputs).union(
+                            missing_inputs)
+
+        for missing_var in sorted(missing_inputs):
+            missing_expr = outputs2expr[missing_var]
+            print(f'{missing_var} = {missing_expr}')
+        print(f'\tRemove from {namespace}.{task_name} call:')
+        for extra_var in sorted(extra_inputs):
+            extra_expr = preexisting[wdl_file][extra_var]
+            print(f'{extra_var} = {extra_expr}')
+
+        # Crude check to obtain the type for populating the task's input 
+        for in_var in list(actual_inputs):
+            # Populate a list of types to ensure there aren't multiple types
+            if in_var in wdl2in2type[wdl_file]:
+                task_in2type[in_var].add(wdl2in2type[wdl_file][in_var])
+            if in_var in wdl2out2type[wdl_file]:
+                task_in2type[in_var].add(wdl2out2type[wdl_file][in_var])
+        print()
+
+    # Report if discrepant types for a given variable name
+    failed_vars = [k for k, v in task_in2type.items() if len(v) > 1]
+    if any(failed_vars):
+        eprint('ERROR: some variables have multiple types across workflows: ')
+        for failed_var in failed_vars:
+            eprint(f'{failed_var} {task_in2type[failed_var]}')
+        sys.exit(6)
+
+    # Report the discrepancies for the input task
+
+    print(input_file)
+    print('\tAdd to inputs:')
+    for var_name, typ in out_hash2wdl:
+        if var_name not in input_inputs:
+            # make all inputs optional
+            if not typ.endswith('?'):
+                typ = typ + '?'
+            print(f'{typ} {var_name}')
+    
+    extraneous_inputs = input_inputs.difference(set(x[0] for x in out_hash2wdl))
+    extraneous_inputs = extraneous_inputs.difference(ignored_inputs)
+    print('\tRemove from inputs:')
+    for inp in sorted(extraneous_inputs):
+        print(f'{inp}')
+    # add removing section
+
+            
+def main(input_file, repo_dir, update = False, task_name = 'export_taxon_tables',
+         ignored_inputs = {'cpu', 'memory', 'disk_size', 'docker'}):
+    """Main function:
+    Compile inputs from input_file
+    ID downstream dependencies
+    Extract I/O from downstream dependencies
+    Extract preexisting inputs to input_file task from dependency
+    Report missing inputs from input_file
+    Report extra inputs from input_file
+    Report missing inputs in dependencies' task calls
+    Report extra inputs in dependencies' task calls
+    """
+    # Check if repo is a git repo
+    if not check_repo_head(repo_dir):
+        eprint("ERROR: Repo directory is not a git repository")
+        sys.exit(1)
+
+    # Get inputs and outputs of focal WDL file
+    task_io, wf_io = get_io(input_file)
+    if task_io and wf_io:
+        eprint("ERROR: this script does not support WDL files with both tasks and workflows")
+        sys.exit(2)
+    elif task_io:
+        wdl_info = task_io
+    else:
+        wdl_info = wf_io
+
+    input_inputs = set(x.name for x in wdl_info['inputs'][task_name])
+
+    # Collect all WDL files in repo and ID dependencies
+    wdl_files_prep = set(collect_files(repo_dir, 'wdl', recursive = True))
+    wdl_files = sorted(wdl_files_prep.difference({input_file}))
+    eprint('Downstream dependencies:')
+    downstream_io, preexisting_inputs = get_downstream(input_file, wdl_info, 
+                                                     wdl_files, repo_dir)
+    if not downstream_io:
+        eprint("No downstream dependencies found")
+        sys.exit(3)
+
+#    eprint('Upstream dependencies:') 
+ #   upstreams = get_upstream(input_file, repo_dir)
+
+    wdl2out_hash, wdl2namespace, wdl2in_hash, wdl2in2type, wdl2out2type \
+        = compile_outputs(downstream_io)
+
+    # Print the new inputs for the focal WDL file
+    if not update:
+        print_changes(input_file, input_inputs, wdl2out_hash, 
+                      wdl2namespace, task_name, preexisting_inputs, task_name,
+                      ignored_inputs, wdl2in_hash, wdl2in2type, wdl2out2type)
+
+def cli():
+    parser = argparse.ArgumentParser(description = "Sync WDL inputs/outputs")
+    parser.add_argument("-i", "--input", help = "WDL file to sync", required = True)
+    parser.add_argument("-r", "--repo", help = "Base repo dir containing WDL files", required = True)
+   # parser.add_argument("-u", "--update", action = "store_true", 
+                     #   help = "Update the focal WDL and dependencies with new I/O")
+    args = parser.parse_args()
+
+    main(format_path(args.input), format_path(args.repo)) #, args.downstream)
+
+
+if __name__ == '__main__':
+    cli()
+    sys.exit(0)

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -344,7 +344,7 @@ def print_changes(input_file, input_inputs, wdl2out_hash,
 
             
 def main(input_file, dependencies, repo_dir, task_name = 'export_taxon_tables',
-         ignored_inputs = {'cpu', 'memory', 'disk_size', 'docker'},
+         ignored_inputs = {'cpu', 'memory', 'disk_size', 'docker', 'sample_taxon'},
          ignored_outputs = {'taxon_table_status'}):
     """Main function:
     Compile inputs from input_file

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -420,9 +420,8 @@ def output_changes(input_file, input_inputs, wdl2out_hash,
     file_obj.write('      "entity:${sample_table}_id": "~{samplename}"')
     for in_var in sorted(task_in2type.keys()):
         file_obj.write(f',\n      "{in_var}": ' + '"~{' + f'{in_var}' + '}"')
-    file_obj.write('\n    }')
+    file_obj.write('\n    }\n\n')
 
-    file_obj.write('\n')
     for doc_file in doc_files:
         doc_changes = compile_documentation_changes(doc_file, actual_inputs, 
                                                     input2files, task_in2type)

--- a/scripts/update_taxon_tables_io.py
+++ b/scripts/update_taxon_tables_io.py
@@ -191,7 +191,7 @@ def get_downstream_remote(foc_file, foc_info,
         wdl_txt = remote_load(wdl_file)
         wdl = WDL.load(StringIO(wdl_txt))
         for wdl_import in wdl.imports:
-            logging.INFO(f'\t{wdl_file}')
+            logging.info(f'\t{wdl_file}')
             task_io, wf_io = get_io(wdl_file)
             namespace = wdl_import.namespace
             downstream[wdl_file] = {'namespace': namespace,


### PR DESCRIPTION
`update_taxon_tables_io.py` facilitates synchronization between `task_export_taxon_table.wdl` (taxon_tables) I/O and its downstream dependencies' I/O. Taxon_tables was prone to becoming desync'ed from its downstream dependencies because any updates to dependency outputs or input names need to propagated to the taxon_tables task call within the dependency.

This script identifies discrepancies that need to be updated. It operates by identifying new outputs from downstream workflows that need to be propagated to taxon_tables, and will retain any preexisting inputs to taxon_tables that reference downstream workflow inputs - additions of new downstream workflow inputs are not recommended for addition. This script will then report which additions and removals need to be made to downstream workflow dependencies' calls of taxon_tables. Special exceptions are granted, e.g. including `sample_taxon` because it is internally used by taxon_tables, and excluding `taxon_table_status` because it is an exposed output in Theia-workflows that is generated by taxon_tables. Additionally, this script accounts for mapped v. nonmapped inputs. Nonmapped inputs are hardcoded.

It currently operates locally, identifying downstream dependencies dynamically, though this script is staged for remote operation using hard-coded dependency links following minor changes. This script is also staged to update these files in place.